### PR TITLE
Fix card header title centering when panel size != 100%

### DIFF
--- a/res/layout/inner_base_header.xml
+++ b/res/layout/inner_base_header.xml
@@ -32,6 +32,7 @@
         android:layout_height="wrap_content"
         android:id="@+id/card_header_inner_simple_title"
         style="@style/card.header_simple_title"
+        android:gravity="center_vertical"
         android:layout_centerVertical="true"/>
 
 </RelativeLayout>


### PR DESCRIPTION
for both one and two rows title